### PR TITLE
Use keywords params for User entity

### DIFF
--- a/src/domain/entities/user.rb
+++ b/src/domain/entities/user.rb
@@ -1,4 +1,3 @@
-require_relative '../value_objects/name'
 require_relative '../value_objects/email'
 require_relative '../value_objects/password'
 require 'securerandom'
@@ -6,12 +5,12 @@ require 'securerandom'
 class User
   attr_reader :id, :name, :email, :password
 
-  def initialize(name, email, password)
+  def initialize(id: SecureRandom.uuid, name: nil, email: nil, password: nil)
     validate_presence(name, email, password)
-    @id = SecureRandom.uuid 
-    @name = Name.new(name)
-    @email = Email.new(email)
-    @password = Password.new(password)
+    @id = id
+    @name = name
+    @email = Email.new(email).value
+    @password = Password.new(password).value
   end
 
   def ==(other)

--- a/src/domain/entities/user_test.rb
+++ b/src/domain/entities/user_test.rb
@@ -1,28 +1,34 @@
 require_relative 'user'
 
 RSpec.describe User do
-  describe "#initialize" do
-    context "with valid name, email, and password" do
-      it "creates a user object" do
-        user = User.new("John Doe", "john@example.com", "password123")
+  describe '#initialize' do
+    context 'with valid name, email, and password' do
+      it 'creates a user object' do
+        user = User.new(id: 1, name: 'John Doe', email: 'john@example.com', password: 'password123')
 
-        expect(user.id).to_not be_nil
-        expect(user.name.value).to eq("John Doe")
-        expect(user.email.value).to eq("john@example.com")
-        expect(user.password.value).to eq("password123")
+        expect(user.id).to be(1)
+        expect(user.name).to eq('John Doe')
+        expect(user.email).to eq('john@example.com')
+        expect(user.password).to eq('password123')
       end
     end
 
-    it "raises ArgumentError with missing name" do
-      expect { User.new(nil, "john@example.com", "password123") }.to raise_error(ArgumentError, 'Name is required')
+    it 'raises ArgumentError with missing name' do
+      expect do
+        User.new(id: 1, email: 'john@example.com', password: 'password123')
+      end.to raise_error(ArgumentError, 'Name is required')
     end
 
-    it "raises ArgumentError with missing email" do
-      expect { User.new("John Doe", nil, "password123") }.to raise_error(ArgumentError, 'Email is required')
+    it 'raises ArgumentError with missing email' do
+      expect do
+        User.new(id: 1, name: 'John Doe', password: 'password123')
+      end.to raise_error(ArgumentError, 'Email is required')
     end
 
-    it "raises ArgumentError with missing password" do
-      expect { User.new("John Doe", "john@example.com", nil) }.to raise_error(ArgumentError, 'Password is required')
+    it 'raises ArgumentError with missing password' do
+      expect do
+        User.new(id: 1, name: 'John Doe', email: 'john@example.com')
+      end.to raise_error(ArgumentError, 'Password is required')
     end
   end
 end

--- a/src/domain/use_cases/add_new_user.rb
+++ b/src/domain/use_cases/add_new_user.rb
@@ -4,7 +4,7 @@ class AddNewUser
   end
 
   def execute(user)
-    if @user_repository.show_all.any? { |u| u.email.value == user.email.value }
+    if @user_repository.show_all.any? { |u| u.email == user.email }
       raise ArgumentError, 'Email already exists'
     end
 

--- a/src/domain/use_cases/add_new_user_test.rb
+++ b/src/domain/use_cases/add_new_user_test.rb
@@ -5,7 +5,7 @@ require_relative '../../data/user_repository_in_memory'
 
 RSpec.describe AddNewUser do
   it 'add user' do
-    user1 = User.new('John Doe', 'john@example.com', 'password123')
+    user1 = User.new(name: 'John Doe', email: 'john@example.com', password: 'password123')
     user_repository_in_memory = UserRepositoryInMemory.new
 
     add_new_user = AddNewUser.new(user_repository_in_memory)
@@ -16,13 +16,13 @@ RSpec.describe AddNewUser do
   end
 
   it 'add user with existing email' do
-    user1 = User.new('John Doe', 'john@example.com', 'password123')
+    user1 = User.new(name: 'John Doe', email: 'john@example.com', password: 'password123')
     user_repository_in_memory = UserRepositoryInMemory.new
 
     add_new_user = AddNewUser.new(user_repository_in_memory)
     add_new_user.execute(user1)
 
-    user2 = User.new('John Papa', 'john@example.com', 'password123')
+    user2 = User.new(name: 'John Papa', email: 'john@example.com', password: 'password123')
     expect { add_new_user.execute(user2) }.to raise_error(ArgumentError, 'Email already exists')
   end
 end

--- a/src/domain/use_cases/show_all_users_test.rb
+++ b/src/domain/use_cases/show_all_users_test.rb
@@ -11,8 +11,8 @@ RSpec.describe ShowAllUsers do
   end
 
   it 'show multiple users' do
-    user1 = User.new('John Doe', 'john@example.com', 'password123')
-    user2 = User.new('Juan', 'juan@example.com', 'password123')
+    user1 = User.new(name: 'John Doe', email: 'john@example.com', password: 'password123')
+    user2 = User.new(name: 'Juan', email: 'juan@example.com', password: 'password123')
 
     user_repository_in_memory = UserRepositoryInMemory.new
 

--- a/src/domain/value_objects/name.rb
+++ b/src/domain/value_objects/name.rb
@@ -1,8 +1,0 @@
-class Name
-  attr_reader :value
-
-  def initialize(value)
-    @value = value
-  end
-
-end

--- a/src/domain/value_objects/name_test.rb
+++ b/src/domain/value_objects/name_test.rb
@@ -1,8 +1,0 @@
-require_relative 'name'
-
-RSpec.describe Name do
-  it 'initialize' do
-    john = Name.new('John')
-    expect(john.name).to eq('John')
-  end
-end


### PR DESCRIPTION
- borrar el `name` value object ya que no es necesary (no tiene ninguna validacion)
- añadir keywords params a la entidad `User` y actualizar los `attr readers` por sus valores para facilitar su lectura (mejor `user.email` que `user.email.value` 😉 )